### PR TITLE
1st draft of lastfm taste-o-meter

### DIFF
--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -14,10 +14,10 @@ LEL = "0,5last.fm"
 NUM_EVENTS = 5
 USERFILE = '/home/mbot/mbot/lastfm-data/lastfm.users'
 CHART_LENGTH = 10
-PRETTY_BAR = ["[4====            ]",
-              "[4====7====        ]",
-              "[4====7====8====    ]",
-              "[4====7====8====9====]",
+PRETTY_BAR = ["[04====            ]",
+              "[04====07====        ]",
+              "[04====07====08====    ]",
+              "[04====07====08====09====]",
               "[                ]"]
 
 def man():
@@ -163,19 +163,31 @@ class LastFM:
 
   def compare_users(self, user, user2):
     try:
-      comparison = self.api.get_user(user).compare_with_user(user2)
-
+      # comparison = self.api.get_user(user).compare_with_user(user2)
+      
+      user1_favs = self.api.get_user(user).get_top_artists('overall', 1000)
+      user2_favs = self.api.get_user(user2).get_top_artists('overall', 1000)
+      
     except pylast.WSError as e:
       print_console(LEL + " WSError %s: %s" % (e.status, e.details))
       exit(-1)
+      
+    n_artists1 = len(user1_favs)
+    n_artists2 = len(user2_favs)
+    
+    user1_favs = [i.item.__str__() for i in user1_favs]
+    user2_favs = [i.item.__str__() for i in user2_favs]
+    
+    intersection = [artist for artist in user1_favs if artist in user2_favs]
+    artist_list = intersection[:5]
 
-    comparison_index = round(float(comparison[0]), 2) * 100
+    comparison_index = round(200.0 * len(intersection) / (n_artists1 + n_artists2), 2)
+    
     if comparison_index < 1.0:
       bar = PRETTY_BAR[4]
     else:
       bar = PRETTY_BAR[int(comparison_index / 25.01)]
 
-    artist_list = comparison[1]
     if artist_list:
       parsed_list = [str(item) for item in artist_list]
       chart_text = ", ".join(parsed_list)


### PR DESCRIPTION
First we get the top 1000 artists of both users. Then I create a new list with the artists in common (intersection).
The intersection index is calculated like this
```2 * c / (n + m)```
where ```c``` is the number of common elements in both lists and ```n + m``` is the size of both lists.

This does not match the results in lastfm and needs tweaking.
The maximum limit is 1000. It may not a good number to use to recreate the taste-o-meter.

Getting too many artists will result in a low match index and too few may also give a low match as it'll miss artists both users don't listen as often.

As a last resort we could just say that if 2 users have 50 artists in common they have a 100% match.