### PR TITLE
cast fiat value to float

### DIFF
--- a/cc/cc.py
+++ b/cc/cc.py
@@ -37,6 +37,6 @@ try:
 except:
 	print_console("No results found")
 	sys.exit(0)
-eur = values['RAW'][coin]['EUR']['PRICE']
-usd = values['RAW'][coin]['USD']['PRICE']
+eur = float(values['RAW'][coin]['EUR']['PRICE'])
+usd = float(values['RAW'][coin]['USD']['PRICE'])
 print_console("%0.2f %s = %0.2f USD = %0.2f EUR" % (ammount, coin, usd * ammount, eur * ammount))


### PR DESCRIPTION
The json output for DOGE sends EUR value in a string but USD in a float.
see here: ```https://min-api.cryptocompare.com/data/pricemultifull?fsyms=DOGE&tsyms=EUR,USD```

Only happens with this coin as far as I can tell.