### PR TITLE
Novo formato com mais informação sobre o processo

### DIFF
--- a/inquisicao/inquisicao.py
+++ b/inquisicao/inquisicao.py
@@ -72,9 +72,6 @@ def autoDeFe(processo, adcautelam=False):
 
     return result
 
-
-
-
 def degredo():
     request = requests.get('https://inquisicao.deadbsd.org/api/degredo', timeout=TIMEOUT)
 

--- a/inquisicao/inquisicao.py
+++ b/inquisicao/inquisicao.py
@@ -14,7 +14,8 @@ TIMEOUT = 5
 def autoDeFe(processo, adcautelam=False):
 
     result = ""
-    moar = True
+    extra = "crime"
+    shown = 0
 
     # Se for pesquisa, mostra o registo actual / total
     if adcautelam:
@@ -29,37 +30,38 @@ def autoDeFe(processo, adcautelam=False):
     # Quase todos têm crime
     if processo['crime']:
         result = "%s | Crime: %s" % (result, processo['crime'])
+        shown = shown + 1
     # Se tiver sentença, nao printa mais dados sobre o processo (moar)
     if processo['sentenca']:
         result = u"%s | Sentença: %s" % (result, processo['sentenca'])
-        moar = False
+        shown = shown + 1
 
-    if moar:
+    if shown < 2:
         # Se tiver notas e outros dados
         if processo['notas'] and processo['outros']:
             # Ver qual deles é maior e printar
             if len(processo['notas']) > len(processo['outros']):
                 result = "%s | Notas: %s" % (result, processo['notas'])
+                extra = "notas"
             else:
                 result = "%s | Outros dados: %s" % (result, processo['outros'])
+                extra = "outros"
         # Senão printa as Notas
         elif processo['notas']:
             result = "%s | Notas: %s" % (result, processo['notas'])
+            extra = "notas"
         # Ou os Outros dados
         elif processo['outros']:
             result = "%s | Outros dados: %s" % (result, processo['outros'])
+            extra = "outros"
 
     # Se for pesquisa
     if adcautelam:
         # Verifica se o match é o mesmo de algum dos items printados
-        # TODO: existe um possivel bug aqui:
-        # * se as "Notas" forem printadas anteriormente
-        # * e o match for no campo "Outros dados"
-        # Não vai printar o match
+        # Tou a comparar duas vezes com o crime quando o "extra" não é definido
         if (processo['crime'] != processo['match']['value'] and
                 processo['sentenca'] != processo['match']['value'] and
-                processo['notas'] != processo['match']['value'] and
-                processo['outros'] != processo['match']['value']):
+                processo[extra] != processo['match']['value']):
 
             # Printa o match
             result = "%s | %s: %s" % (

--- a/inquisicao/inquisicao.py
+++ b/inquisicao/inquisicao.py
@@ -13,7 +13,7 @@ from mylib import print_console
 TIMEOUT = 5
 
 def auto_de_fe(processo, pesquisa=False):
-    """Devolve uma string bonita sobre o processo """
+    """Devolve uma string bonita sobre o processo"""
 
     result = ""
     extra = "crime"
@@ -41,9 +41,10 @@ def auto_de_fe(processo, pesquisa=False):
     # Se printou menos de 2 registos
     if shown < 2:
         # Se tiver "Notas" e "Outros dados"
-        # Define a variavel extra com o valor da chave que foi extra-printada
         if processo['notas'] and processo['outros']:
-            # Ver qual deles é maior e printar
+            # Ver qual deles é maior e printa.
+            # Define a variavel "extra" com o valor da chave que foi
+            # extra-printada, para ser utilizada em caso de pesquisa
             if len(processo['notas']) > len(processo['outros']):
                 result = "%s | Notas: %s" % (result, processo['notas'])
                 extra = "notas"
@@ -61,8 +62,8 @@ def auto_de_fe(processo, pesquisa=False):
 
     # Se for pesquisa
     if pesquisa:
-        # Verifica se o match é o mesmo de algum dos items printados
-        # Tou a comparar duas vezes com o crime quando o "extra" não é definido
+        # Verifica se o match é o mesmo que algum dos items já printados
+        # Estou a comparar duas vezes com o Crime quando o "extra" não é definido
         if (processo['crime'] != processo['match']['value'] and
                 processo['sentenca'] != processo['match']['value'] and
                 processo[extra] != processo['match']['value']):

--- a/inquisicao/inquisicao.py
+++ b/inquisicao/inquisicao.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import requests
-import json
+"""Consome a API da Inquisição para ser usado com o mbot-shell."""
+
 import re
 import sys
 import os
+import requests
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from mylib import print_console
 
 TIMEOUT = 5
 
-def autoDeFe(processo, adcautelam=False):
+def auto_de_fe(processo, pesquisa=False):
+    """Devolve uma string bonita sobre o processo """
 
     result = ""
     extra = "crime"
     shown = 0
 
     # Se for pesquisa, mostra o registo actual / total
-    if adcautelam:
+    if pesquisa:
         result = "[%d/%d] " % (
             processo['next'] - 1 if processo['next'] else processo['total'],
             processo['total'])
@@ -31,7 +33,7 @@ def autoDeFe(processo, adcautelam=False):
     if processo['crime']:
         result = "%s | Crime: %s" % (result, processo['crime'])
         shown = shown + 1
-    # Printa a Senteça se existir, e incrementa o shown
+    # Printa a Sentença se existir, e incrementa o shown
     if processo['sentenca']:
         result = u"%s | Sentença: %s" % (result, processo['sentenca'])
         shown = shown + 1
@@ -58,7 +60,7 @@ def autoDeFe(processo, adcautelam=False):
             extra = "outros"
 
     # Se for pesquisa
-    if adcautelam:
+    if pesquisa:
         # Verifica se o match é o mesmo de algum dos items printados
         # Tou a comparar duas vezes com o crime quando o "extra" não é definido
         if (processo['crime'] != processo['match']['value'] and
@@ -77,20 +79,26 @@ def autoDeFe(processo, adcautelam=False):
     return result
 
 def degredo():
+    """Processo aleatorio"""
+
     request = requests.get('https://inquisicao.deadbsd.org/api/degredo', timeout=TIMEOUT)
 
     j = request.json()
-    result = autoDeFe(j)
+    result = auto_de_fe(j)
     print_console(result)
 
-def adcautelam(key, page):
-    request = requests.get('https://inquisicao.deadbsd.org/api/adcautelam?key=' + key + '&page=' + str(page), timeout=TIMEOUT)
+def ad_cautelam(key, page):
+    """Pesquisa em elementos de um Processo"""
+
+    request = requests.get(
+        'https://inquisicao.deadbsd.org/api/adcautelam?key=' + key +
+        '&page=' + str(page), timeout=TIMEOUT)
 
     if request.status_code == 404:
         print_console("Not found")
     else:
         j = request.json()
-        result = autoDeFe(j, adcautelam=True)
+        result = auto_de_fe(j, pesquisa=True)
         print_console(result)
 
 if __name__ == "__main__":
@@ -109,4 +117,4 @@ if __name__ == "__main__":
             PAGE = int(MATCH.group('page').strip())
 
         if KEY:
-            adcautelam(KEY, PAGE)
+            ad_cautelam(KEY, PAGE)

--- a/inquisicao/inquisicao.py
+++ b/inquisicao/inquisicao.py
@@ -27,17 +27,19 @@ def autoDeFe(processo, adcautelam=False):
     # Titulo
     result = "%s%s" % (result, processo['titulo'])
 
-    # Quase todos têm crime
+    # Printa o Crime se existir, e incrementa o shown
     if processo['crime']:
         result = "%s | Crime: %s" % (result, processo['crime'])
         shown = shown + 1
-    # Se tiver sentença, nao printa mais dados sobre o processo (moar)
+    # Printa a Senteça se existir, e incrementa o shown
     if processo['sentenca']:
         result = u"%s | Sentença: %s" % (result, processo['sentenca'])
         shown = shown + 1
 
+    # Se printou menos de 2 registos
     if shown < 2:
-        # Se tiver notas e outros dados
+        # Se tiver "Notas" e "Outros dados"
+        # Define a variavel extra com o valor da chave que foi extra-printada
         if processo['notas'] and processo['outros']:
             # Ver qual deles é maior e printar
             if len(processo['notas']) > len(processo['outros']):


### PR DESCRIPTION
Oi sir,

Quando não existe "Crime" ou "Sentença" num processo, agora verifica se também existem "Notas" ou "Outros dados" (adicionei-os à API) relacionados com o processo e printa o maior/o que existir deles.

Fiz uma função chamada auto_de_fe para formatar a mensagem no formato *standard* e tentei comentar tudo o que faz, porque acho que está um bocado ghetto.

> Processo de Maria Rodrigues | Crime: Feitiçaria; Superstição; Pacto com o demónio | Outros dados: OUVIDA EM 1700, MARÇO, 08; POSTA EM LIBERDADE, DEPOIS DE ÀSPERAMENTE REPREENDIDA EM 12 DE MARÇO DFO MESMO ANO. | https://goo.gl/M4EH1K

> [2/2] Processo de Manuel Fernandes | Crime: Sodomia | Outros dados: M.C., MANCHADO, 4 FOLHAS SOLTAS, TENDO A 1ª UM PEDAÇO RASGADO; FORAM PASSADOS AO RÉU TERMOS DE SOLTURA E SEGREDO EM 1711-06-23 E DE IDA E PENITÊNCIAS EM 1711-08-22. | Outras formas do nome: o Maricas | https://goo.gl/M8ScpY

Testei isto umas quantas vezes e pareceu-me estar tudo OK, mas o melhor mesmo é testar em produção :-D

Como estava aborrecido adicionei também docstrings às funções em Português para ficar um belo de um PT-EN-LATIN como o Theorem disse. E também corrigi a maioria dos dramas que o pylint se queixava.

Gostaria também de fazer algo em relação aos processos que são bues de texto e fazem alta flood no IRC. A minha ideia é apanhar a mensagem antes de adicionar a ultima parte que é " | shorturl", e cortar por um determinado numero de caracteres e adicionar três pontinhos.

Que achas? Ou alguma outra ideia?